### PR TITLE
Merge Main into Oss

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "sonner": "^2.0.6",
     "stripe": "^17.7.0",
     "tailwind-merge": "^2.6.0",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.0",
     "zod": "^3.25.76"
   },
   "packageManager": "pnpm@10.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -5123,6 +5123,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -10821,6 +10825,8 @@ snapshots:
       react: 19.0.0
 
   util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
This pull request updates the `uuid` package to version `11.1.0` across the project. The changes ensure consistency in dependencies and lock files.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L98-R98): Updated the `uuid` package version from `^9.0.1` to `^11.1.0`.

* `pnpm-lock.yaml`:
  - Updated the `uuid` package version under `importers` from `^9.0.1` to `^11.1.0`.
  - Added a new entry for `uuid@11.1.0` under `packages` with its resolution and metadata.
  - Added a new snapshot entry for `uuid@11.1.0`.